### PR TITLE
Fix misleading documentation

### DIFF
--- a/doc_source/how-transit-gateways-work.md
+++ b/doc_source/how-transit-gateways-work.md
@@ -11,9 +11,9 @@ A transit gateway attachment is both a source and a destination of packets\. You
 
 ## Availability Zones<a name="tgw-az-overview"></a>
 
-When you attach a VPC to a transit gateway, you must enable one or more Availability Zones to be used by the transit gateway to route traffic to resources in the VPC subnets\. To enable each Availability Zone, you specify exactly one subnet\. The transit gateway places a network interface in that subnet using one IP address from the subnet\. After you enable an Availability Zone, traffic can be routed to all subnets in that Availability Zone, not just the specified subnet\.
+When you attach a VPC to a transit gateway, you must enable one or more Availability Zones to be used by the transit gateway to route traffic to resources in the VPC subnets\. To enable each Availability Zone, you specify exactly one subnet\. The transit gateway places a network interface in that subnet using one IP address from the subnet\. After you enable an Availability Zone, traffic can be routed to all subnets in that Availability Zone, not just the specified subnet\. Resources residing in Availability Zones where there is no TG attachment will not be able to reach the Transit Gateway.
 
-We recommend that you enable multiple Availability Zones to ensure availability\. If one Availability Zone becomes unavailable or has no healthy attachments, the transit gateway can route traffic to your VPC using a healthy attachment in a different Availability Zone\.
+We recommend that you enable multiple Availability Zones to ensure availability\.
 
 ## Routing<a name="tgw-routing-overview"></a>
 


### PR DESCRIPTION
Documentation was misleading. Cannot route from TG to AZ where there is no TG attachment. Refer AWS Support Case 6370451181

*Issue 6370451181*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
