### PR TITLE
Clarified support of TGW peering for IPv6

### DIFF
--- a/doc_source/tgw-peering.md
+++ b/doc_source/tgw-peering.md
@@ -1,6 +1,6 @@
 # Transit Gateway Peering Attachments<a name="tgw-peering"></a>
 
-You can peer two transit gateways and route traffic between them\. To do this, create a peering attachment on your transit gateway, and specify a transit gateway in another AWS Region\. The peer transit gateway can be in your account or a different AWS account\. 
+You can peer two transit gateways and route traffic between them, which includes IPv4 and IPv6 traffic\. To do this, create a peering attachment on your transit gateway, and specify a transit gateway in another AWS Region\. The peer transit gateway can be in your account or a different AWS account\. 
 
 After you create a peering attachment request, the owner of the peer transit gateway \(also referred to as the *accepter transit gateway*\) must accept the request\.
 


### PR DESCRIPTION
Clarified that TGW peering supports routing and transport of IPv6 traffic.

*Issue #, if available:*

*Description of changes:*
Clarified that TGW peering supports routing and transport of IPv6 traffic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
