### PR TITLE
Update transit-gateway-quotas.md

### DIFF
--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -21,7 +21,7 @@ Your AWS account has the following service quotas \(previously referred to as *l
 
 ## Bandwidth<a name="bandwidth-quota"></a>
 + Maximum bandwidth \(burst\) per VPC connection: 50 Gbps
-+ Maximum bandwidth per VPN connection: 1\.25 Gbps
++ Maximum bandwidth per VPN tunnel: 1\.25 Gbps
 
   This is a hard value\. You can use ECMP to get higher VPN bandwidth by aggregating multiple VPN tunnels\.
 


### PR DESCRIPTION
Changed from connection to tunnel as this is per tunnel and not connection. 

Note: This is correctly stated in VPN FAQ: https://aws.amazon.com/vpn/faqs/
"Q: What is the approximate maximum throughput of a Site-to-Site VPN connection?

A: Each AWS Site-to-Site VPN connection has two tunnels and each tunnel supports a maximum throughput of up to 1.25 Gbps. If your VPN connection is to a Virtual Private Gateway, aggregated throughput limits would apply."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
