### PR TITLE
Update tgw-peering.md

### DIFF
--- a/doc_source/tgw-peering.md
+++ b/doc_source/tgw-peering.md
@@ -6,7 +6,7 @@ After you create a peering attachment request, the owner of the peer transit gat
 
 We recommend using unique ASNs for the peered transit gateways to take advantage of future route propagation capabilities\.
 
-Note: Transit Gateway cross-region peering attachments currently do not support resolving public DNS hostnames to private IP addresses from source to destination VPC as VPC cross-region peering does.
+Note: Transit gateway cross-region peering does not support resolving public IPv4 DNS hostnames to private IPv4 addresses across VPCs on either side of the transit gateway peering attachment. 
 
 Transit gateway peering attachments are not supported in the following AWS Regions: Asia Pacific \(Hong Kong\), Asia Pacific \(Osaka\-Local\), and Middle East \(Bahrain\)\.
 

--- a/doc_source/tgw-peering.md
+++ b/doc_source/tgw-peering.md
@@ -6,6 +6,8 @@ After you create a peering attachment request, the owner of the peer transit gat
 
 We recommend using unique ASNs for the peered transit gateways to take advantage of future route propagation capabilities\.
 
+Note: Transit Gateway cross-region peering attachments currently do not support resolving public DNS hostnames to private IP addresses from source to destination VPC as VPC cross-region peering does.
+
 Transit gateway peering attachments are not supported in the following AWS Regions: Asia Pacific \(Hong Kong\), Asia Pacific \(Osaka\-Local\), and Middle East \(Bahrain\)\.
 
 ## Create a peering attachment<a name="tgw-peering-create"></a>


### PR DESCRIPTION
Added note to clarify that currently Transit Gateway cross-region peering do no support DNS resolution which is to resolve a public DNS name to the instance private IP as it would when VPCs are attached to the same TGW. This is different than the cross-region VPC peering behavior: https://aws.amazon.com/about-aws/whats-new/2018/11/announcing-support-for-dns-resolution-over-inter-region-vpc-peering/ where you can resolve DNS hostnames to private IP addresses when queried from a peered VPC in another AWS Region.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
