### PR TITLE
Update transit-gateway-quotas.md

### DIFF
--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -20,7 +20,7 @@ Your AWS account has the following service quotas \(previously referred to as *l
 + Number of pending transit gateway peering attachments transit gateway:10
 
 ## Bandwidth<a name="bandwidth-quota"></a>
-+ Maximum bandwidth \(burst\) per VPC connection: 50 Gbps
++ Maximum bandwidth (burst) per VPC, Direct Connect gateway, or peered Transit Gateway connection: 50 Gbps (Default)
 + Maximum bandwidth per VPN tunnel: 1\.25 Gbps
 
   This is a hard value\. You can use ECMP to get higher VPN bandwidth by aggregating multiple VPN tunnels\.

--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -20,7 +20,7 @@ Your AWS account has the following service quotas \(previously referred to as *l
 + Number of pending transit gateway peering attachments transit gateway:10
 
 ## Bandwidth<a name="bandwidth-quota"></a>
-+ Maximum bandwidth (burst) per VPC, Direct Connect gateway, or peered Transit Gateway connection: 50 Gbps (Default)
++ Maximum bandwidth (burst) per VPC, Direct Connect gateway, or peered transit gateway connection: 50 Gbps
 + Maximum bandwidth per VPN tunnel: 1\.25 Gbps
 
   This is a hard value\. You can use ECMP to get higher VPN bandwidth by aggregating multiple VPN tunnels\.


### PR DESCRIPTION
Updated the max bandwidth to include DXGW and Peering attachment bandwidth. This is to make it consistent with the FAQs: https://aws.amazon.com/transit-gateway/faqs/ --> Performance and limits section, as it is called out in the FAQs but not here on this page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
