### PR TITLE
Update tgw-multicast-overview.md

### DIFF
--- a/doc_source/tgw-multicast-overview.md
+++ b/doc_source/tgw-multicast-overview.md
@@ -18,4 +18,4 @@ The following are the key concepts for multicast:
 + A subnet can only be in one multicast domain\. 
 + If you use a non\-Nitro instance, you must disable the **Source/Dest** check\. For information about disabling the check, see [Changing the source or destination checking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#change_source_dest_check) in the *Amazon EC2 User Guide for Linux Instances*\.
 + A non\-Nitro instance cannot be a multicast sender\.
-+ VPN and Direct Connect currently do not support multicast. There is no way to bring traffic over VPN or Direct Connect to the Transit Gateway and then forward it to multicast destinations inside your environments\. 
++ Multicast routing is not supported over AWS Direct Connect, Site-to-Site VPN, and peering attachments\. 

--- a/doc_source/tgw-multicast-overview.md
+++ b/doc_source/tgw-multicast-overview.md
@@ -18,3 +18,4 @@ The following are the key concepts for multicast:
 + A subnet can only be in one multicast domain\. 
 + If you use a non\-Nitro instance, you must disable the **Source/Dest** check\. For information about disabling the check, see [Changing the source or destination checking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#change_source_dest_check) in the *Amazon EC2 User Guide for Linux Instances*\.
 + A non\-Nitro instance cannot be a multicast sender\.
++ VPN and Direct Connect currently do not support multicast. There is no way to bring traffic over VPN or Direct Connect to the Transit Gateway and then forward it to multicast destinations inside your environments\. 


### PR DESCRIPTION
Added for clarity that currently VPN and Direct Connect do not support Transit Gateway multicast. Source: AWS Networking Series Episode 4, Ask the Experts 1:13:30 min mark https://www.twitch.tv/videos/686706801?collection=HBANRY7lIxagXQ&t=1h13m33s

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
