### PR TITLE
Update transit-gateway-quotas.md

### DIFF
--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -14,6 +14,7 @@ Your AWS account has the following service quotas \(previously referred to as *l
 ## Transit gateway attachments<a name="attachments-quota"></a>
 + Total number of transit gateway attachments per transit gateway: 5,000
 + Number of transit gateway attachments per VPC: 5
+Note: Single transit gateway can only have one attachment to the same VPC
 
   This value cannot be increased\.
 + Number of transit gateway peering attachments per transit gateway: 50

--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -13,10 +13,9 @@ Your AWS account has the following service quotas \(previously referred to as *l
 
 ## Transit gateway attachments<a name="attachments-quota"></a>
 + Total number of transit gateway attachments per transit gateway: 5,000
-+ Number of transit gateway attachments per VPC: 5
-Note: Single transit gateway can only have one attachment to the same VPC
-
-  This value cannot be increased\.
++ Number of unique transit gateway attachments per VPC: 5
+  
+  This value cannot be increased. A transit gateway cannot have more than one attachment to the same VPC\.
 + Number of transit gateway peering attachments per transit gateway: 50
 + Number of pending transit gateway peering attachments transit gateway:10
 


### PR DESCRIPTION
Added line #17 for clarity. The way original line #16 come across is confusing that you can have multiple TGW attachments from a single TGW to the same VPC, which is not true. The original sentence line #16 actually mean one VPC can have up to 5 attachments to 5 separate TGWs. Fee free to re-word the original line #16 if it can be made clear vs adding an extra note (line #17) as long as it read correctly. Thanks

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
