### PR TITLE
Update tgw-peering.md

### DIFF
--- a/doc_source/tgw-peering.md
+++ b/doc_source/tgw-peering.md
@@ -8,6 +8,8 @@ We recommend using unique ASNs for the peered transit gateways to take advantage
 
 Transit gateway cross\-region peering does not support resolving public IPv4 DNS host names to private IPv4 addresses across VPCs on either side of the transit gateway peering attachment\.
 
+Traffic using inter-region Transit Gateway peering is always encrypted and stays on the AWS global network. For more information about VPC encryption, [Encryption in transit](https://docs.aws.amazon.com/vpc/latest/userguide/data-protection.html#encryption-transit) in the Amazon VPC User Guide.
+
 Transit gateway peering attachments are not supported in the following AWS Regions: Asia Pacific \(Hong Kong\), Asia Pacific \(Osaka\-Local\), and Middle East \(Bahrain\)\.
 
 ## Create a peering attachment<a name="tgw-peering-create"></a>


### PR DESCRIPTION
Added line #11 for clarity and consistency. Reference: https://aws.amazon.com/about-aws/whats-new/2020/04/aws-transit-gateway-now-supports-inter-region-peering-in-11-additional-regions/. Note that line #11 show in the public docs but missing here in the Github copy.

The Github version is out of sync from line #10 - #13 from the public docs. This make proposing any update the docs very challenging as you see on thing in the public docs, but then when you look at the Github version for the same it's missing. I hope this can be fixed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
