### PR TITLE
Update working-with-multicast.md

### DIFF
--- a/doc_source/working-with-multicast.md
+++ b/doc_source/working-with-multicast.md
@@ -1,6 +1,6 @@
 # Working with multicast<a name="working-with-multicast"></a>
 
-You can configure multicast on transit gateways using the Amazon VPC console or the AWS CLI\.
+You can configure multicast on transit gateways using the Amazon VPC console or the AWS CLI\. Note: Currently multicast on transit gateways is only available in the following AWS regions: US East (N. Virginia), Europe (Frankfurt), South America (São Paulo), Middle East (Bahrain), Asia Pacific (Hong Kong) and Asia Pacific (Seoul). 
 
 **Topics**
 + [Create a transit gateway multicast domain](#create-tgw-domain)


### PR DESCRIPTION
Added region info to line #3. Reference: https://aws.amazon.com/about-aws/whats-new/2019/12/run-ip-multicast-workloads-aws-transit-gateway/ and https://aws.amazon.com/about-aws/whats-new/2020/07/ip-multicast-on-aws-transit-gateway-is-now-available-in-europe-frankfurt-south-america-sao-paulo-middle-east-bahrain-asia-pacific-hong-kong-and-asia-pacific-seoul-aws-regions/. Currently this info is not mentioned anywhere, not even in the TGW FAQs, which is odd. Finding this info is like finding a needle in a hay stack.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
