### PR TITLE
Update tgw-multicast-overview.md

### DIFF
--- a/doc_source/tgw-multicast-overview.md
+++ b/doc_source/tgw-multicast-overview.md
@@ -11,8 +11,7 @@ The following are the key concepts for multicast:
 + **Multicast group member** — An elastic network interface associated with a supported EC2 instance that receives multicast traffic\. A multicast group has multiple group members\.
 
 ## Considerations<a name="limits"></a>
-+ For information about supported Regions, see [AWS Transit Gateway FAQs](https://aws.amazon.com/transit-gateway/faqs)\.
-+ You must create a new transit gateway to enable multicast\.
++ + You must create a new transit gateway to enable multicast\.
 + You cannot share multicast\-enabled transit gateways with other accounts \(using AWS Resource Access Manager\)\.
 + Multicast group membership is managed using Amazon VPC Console or the AWS CLI\. 
 +   [Internet Group Management Protocol \(IGMP\)](https://en.wikipedia.org/wiki/Internet_Group_Management_Protocol) support for managing group membership will come in the future\.


### PR DESCRIPTION
Removed linne #14. "For information about supported Regions, see AWS Transit Gateway FAQs". The title is "multicast" but this bullet just say for supported regions see FAQs. Supported regions for what?. Transit Gateway (TGW), Peering attachment support, multicast support?. The FAQs only list the regions where TGW and peering attachments are currently supported and not multicast. So, what's the point adding this bullet here then if it does not point to supported multicast regions?. Please fixx this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
