### PR TITLE
Remove extra . in NATGW and IGW route table CIDR

### DIFF
--- a/doc_source/transit-gateway-nat-igw.md
+++ b/doc_source/transit-gateway-nat-igw.md
@@ -49,7 +49,7 @@ The subnet which contains the IP address of the NAT gateway, has a route table w
 
 | Destination | Target | 
 | --- | --- | 
-|  10\.\.0\.0\.0/16  |  *tgw\-id*  | 
+|  10\.0\.0\.0/16  |  *tgw\-id*  | 
 | 0\.0\.0\.0/0 | igw\-id | 
 
 ### Internet gateway subnet route table<a name="transit-gateway-nat-igw-igw-route-table"></a>
@@ -59,4 +59,4 @@ The subnet which contains the IP address of the internet gateway, has a route ta
 
 | Destination | Target | 
 | --- | --- | 
-|  10\.\.0\.0\.0/16  |  *nat\-gateway\-id*  | 
+|  10\.0\.0\.0/16  |  *nat\-gateway\-id*  | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Got rid of extraneous periods in the 10.X CIDR blocks in the NATGW and IGW subnet route tables

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
