### PR TITLE
Correct maximum multicast throughput per flow

### DIFF
--- a/doc_source/transit-gateway-quotas.md
+++ b/doc_source/transit-gateway-quotas.md
@@ -71,7 +71,7 @@ Your AWS account has the following service quotas \(previously referred to as *l
 + Number of sources per transit gateway multicast group: 1
 + Number of static multicast group and IGMPv2 multicast group members and sources per transit gateway: 10,000 
 + Number of static multicast group and IGMPv2 multicast group members per transit gateway multicast group: 100
-+ Maximum multicast throughput per flow \(in packets per seconds\): 1 Gbps 
++ Maximum multicast throughput per flow: 1 Gbps 
 + Maximum aggregate multicast throughput per subnet: 4 Gbps 
 + Maximum aggregate multicast throughput per subnet including unicast traffic: 50 Gbps 
 


### PR DESCRIPTION
*Issue #, if available:*
The throughput is either given as bits per second (bit/s or bps) *OR* in data packets per second (p/s or pps). Both at the same time doesn't make sense.

*Description of changes:*
As value is given in Gbps, remove incorrect reference to packets per second. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
