### PR TITLE
Update transit-gateway-peering-scenario.md

### DIFF
--- a/doc_source/transit-gateway-peering-scenario.md
+++ b/doc_source/transit-gateway-peering-scenario.md
@@ -54,7 +54,7 @@ The following is an example of the default route table for transit gateway 2, wi
 
 | Destination | Target | Route type | 
 | --- | --- | --- | 
-|  172\.31\.0\.0/16  | Attachment ID for VPN connection  |  propagated  | 
+|  172\.31\.0\.0/24  | Attachment ID for VPN connection  |  propagated  | 
 |  10\.0\.0\.0/16  |  *Attachment ID for peering connection *  |  static  | 
 |  10\.2\.0\.0/16  | Attachment ID for peering connection  | static | 
 


### PR DESCRIPTION
Changed propagated route from 172.31.0.0/16 to 172.31.0.0/24 in default route table of transit gateway 2 . This is in reference to scenario diagram

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
