### PR TITLE
Correction for Route Analyzer navigation.

### DIFF
--- a/doc_source/route-analyzer.md
+++ b/doc_source/route-analyzer.md
@@ -33,7 +33,13 @@ To use the Route Analyzer, you must use the Network Manager console\.
 
 1. Open the Network Manager console at [https://console\.aws\.amazon\.com/networkmanager/home](https://console.aws.amazon.com/networkmanager/home)\.
 
-1. Choose the ID for your global network, and then **Transit gateway network**\. Finally choose **Route Analyzer**\.
+1. Choose **Get started**\. 
+ 
+1. In the navigation pane, choose **Global networks**, and then choose the global network ID\.
+
+1. In the navigation pane, choose **Transit gateway network**\. 
+
+1. Choose the **Route Analyzer** tab\.
 
 1. Under **Source**, do the following:
    + Choose the transit gateway and the transit gateway attachment\.

--- a/doc_source/route-analyzer.md
+++ b/doc_source/route-analyzer.md
@@ -33,7 +33,7 @@ To use the Route Analyzer, you must use the Network Manager console\.
 
 1. Open the Network Manager console at [https://console\.aws\.amazon\.com/networkmanager/home](https://console.aws.amazon.com/networkmanager/home)\.
 
-1. Choose the ID for your global network, and then choose **Route Analyzer**\.
+1. Choose the ID for your global network, and then **Transit gateway network**\. Finally choose **Route Analyzer**\.
 
 1. Under **Source**, do the following:
    + Choose the transit gateway and the transit gateway attachment\.


### PR DESCRIPTION
Instead of saying "Choose the ID for your global network, and then choose Route Analyzer", the text should say "Choose the ID for your global network, and then Transit gateway network. Finally choose Route Analyzer". (or similar navigation steps....)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
